### PR TITLE
Fix `error: TS2322 [ERROR]:`

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -3,7 +3,7 @@ import { h } from "preact";
 import { tw } from "@twind";
 
 interface ButtonProps {
-  class: string;
+  onClick: h.JSX.MouseEventHandler<HTMLButtonElement>;
   children: string;
 }
 


### PR DESCRIPTION
Introduced in af5745a.

Basically, what I need to do is to clean up my props interface, it did not include the correct attributes.

```
error: TS2322 [ERROR]: Type '{ children: string; onClick: () => void; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
  Property 'onClick' does not exist on type 'IntrinsicAttributes & ButtonProps'.
        onClick={() => switchCollapseState()}
        ~~~~~~~
    at file:///home/christoffer/personal/hello-world/islands/CollapseButton.tsx:37:9
```