### PR TITLE
Make sure `deno fmt` is ran after deps update

### DIFF
--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -18,6 +18,9 @@ jobs:
         run: |
           deno run -A -r https://fresh.deno.dev/update .
 
+      - name: Run formatting
+        run: deno fmt
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         id: pr


### PR DESCRIPTION
This PR https://github.com/Chrizpy/hello-world/pull/9 show's an example where import_map.json doesn't have a newline at the end of the file.

Running deno fmt will resolve this.